### PR TITLE
Install code analysis and debugging tools

### DIFF
--- a/deps/debugging-tools.sh
+++ b/deps/debugging-tools.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# vagrant-cookbook
+# Copyright (C) 2016 Pelagicore AB
+#      
+# Permission to use, copy, modify, and/or distribute this software for 
+# any purpose with or without fee is hereby granted, provided that the 
+# above copyright notice and this permission notice appear in all copies. 
+#  
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL 
+# WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED  
+# WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR 
+# BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES 
+# OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, 
+# WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, 
+# ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS 
+# SOFTWARE.
+#   
+# For further information see LICENSE
+# 
+
+echo "Installing debugging tools"
+
+function install {
+    packages="$@"
+
+    retval=100
+    count=0
+
+    if [[ "$retval" -ne "0" && $count -le 5 ]]; then
+        count=$count+1
+        DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confnew" --force-yes -fuy install $packages
+        retval=$?
+    fi
+
+    if [[ "$retval" -ne "0" ]]; then
+        echo "Failed to install " $packages
+        exit $retval
+    fi
+
+}
+
+# For code analysis
+install valgrind
+
+# For debugging
+install gdb
+install strace


### PR DESCRIPTION
Install valgrind, gdb and strace.
Making it possible to run valgrind when running tests.