### PR TITLE
Some fixes in system-config scripts

### DIFF
--- a/system-config/apt-cacher.sh
+++ b/system-config/apt-cacher.sh
@@ -40,7 +40,8 @@ fi
 if [ "$retval" == "0" ] ; then 
     echo "Adding apt proxy to target" 
     echo -e "Acquire::http::Proxy \"http://$server:3142\";\n" > /etc/apt/apt.conf.d/80proxysettings
-    apt-get update
 else
     echo "Failed to set apt-proxy to $server"
 fi
+
+apt-get update

--- a/system-config/select-apt-mirror.sh
+++ b/system-config/select-apt-mirror.sh
@@ -44,7 +44,10 @@ function install {
 
 }
 
-rm sources.list
+if [ -e "sources.list" ]; then
+    rm sources.list
+fi
+
 install netselect-apt
 sudo netselect-apt -s -o sources.list $releaseName
 mv sources.list /etc/apt/sources.list


### PR DESCRIPTION
select-apt-mirror: only do rm if file exists.
apt-cacher: run apt-get update no matter what