### PR TITLE
Breaks out softwarecontainer deps from common

### DIFF
--- a/deps/common-build-dependencies.sh
+++ b/deps/common-build-dependencies.sh
@@ -42,19 +42,11 @@ function install {
 }
 
 # Common dependencies
-install git cmake build-essential pkg-config
-
+install git cmake build-essential pkg-config automake
 
 # Common for ivi-logging & pelagicore-utils
 install libglib2.0-dev
 
-# For softwarecontainer
-install libdbus-c++-dev libdbus-c++-1-0v5 libdbus-1-dev libglibmm-2.4-dev libglibmm-2.4 \
-    lxc-dev libpulse-dev unzip bridge-utils lcov
-
 # For jsonparser
 install libjansson-dev libjansson4 doxygen graphviz
-
-# For softwarecontainer examples
-install dbus-x11
 

--- a/deps/pulseaudio-dependencies.sh
+++ b/deps/pulseaudio-dependencies.sh
@@ -45,5 +45,5 @@ function install {
 
 }
 
-install pulseaudio
+install pulseaudio libpulse-dev
 

--- a/deps/softwarecontainer-dependencies.sh
+++ b/deps/softwarecontainer-dependencies.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# vagrant-cookbook
+# Copyright (C) 2015 Pelagicore AB
+#
+# Permission to use, copy, modify, and/or distribute this software for
+# any purpose with or without fee is hereby granted, provided that the
+# above copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+# WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR
+# BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES
+# OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+# WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+# ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS
+# SOFTWARE.
+#
+# For further information see LICENSE
+#
+#
+# Usage: softwarecontainer-dependencies.sh
+#
+# Installs dependencies for softwarecontainer
+#
+
+echo "Installing softwarecontainer dependencies"
+
+function install {
+    packages="$@"
+
+    retval=100
+    count=0
+
+    if [[ "$retval" -ne "0" && $count -le 5 ]]; then
+        count=$count+1
+        DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confnew" --force-yes -fuy install $packages
+        retval=$?
+    fi
+    if [[ "$retval" -ne "0" ]]; then
+        exit $retval
+    fi
+}
+
+# For softwarecontainer
+install libdbus-c++-dev libdbus-1-dev libglibmm-2.4-dev libglibmm-2.4 \
+        unzip bridge-utils lcov libjansson-dev libjansson4 \
+        dbus-x11 libcap-dev
+
+# Download and install lxc
+git clone git://github.com/lxc/lxc -b stable-2.0
+cd lxc
+./autogen.sh
+
+./configure --prefix=/usr --enable-capabilities --with-distro=debian
+make
+sudo make install

--- a/system-config/select-apt-mirror.sh
+++ b/system-config/select-apt-mirror.sh
@@ -18,8 +18,11 @@
 # For further information see LICENSE
 # 
 # This script changes the apt mirror to use.
+#
+# Usage: select-apt-mirror.sh [release]
+#
 
-if [[ "$1" -ne "" ]]; then
+if [ -n "$1" ]; then
     releaseName="$1"
 else 
     releaseName="testing"

--- a/system-config/select-apt-mirror.sh
+++ b/system-config/select-apt-mirror.sh
@@ -20,7 +20,7 @@
 # This script changes the apt mirror to use.
 
 if [[ "$1" -ne "" ]]; then
-    releaseName=$1
+    releaseName="$1"
 else 
     releaseName="testing"
 fi
@@ -52,3 +52,4 @@ install netselect-apt
 sudo netselect-apt -s -o sources.list $releaseName
 mv sources.list /etc/apt/sources.list
 
+apt-get update


### PR DESCRIPTION
Also, builds LXC from source instead of from apt (in case of debian stable),
so easier to build from git.

Also puts the pulse deps from SC in pulse deps (not a hard dep for
softwarecontainer anymore) and adds automake to common deps.