### PR TITLE
Do apt-get update before installing netselect-apt

### DIFF
--- a/system-config/select-apt-mirror.sh
+++ b/system-config/select-apt-mirror.sh
@@ -22,6 +22,8 @@
 # Usage: select-apt-mirror.sh [release]
 #
 
+apt-get update
+
 if [ -n "$1" ]; then
     releaseName="$1"
 else 
@@ -52,7 +54,7 @@ if [ -e "sources.list" ]; then
 fi
 
 install netselect-apt
-sudo netselect-apt -s -o sources.list $releaseName
+sudo netselect-apt -f -s -o sources.list $releaseName
 mv sources.list /etc/apt/sources.list
 
 apt-get update


### PR DESCRIPTION
If the box is out of date, we can get 404 from apt since the
apt cache will be too old.

Signed-off-by: Tobias Olausson <tobias.olausson@pelagicore.com>