### PR TITLE
softwarecontainer-dependencies: Add libtool

### DIFF
--- a/deps/softwarecontainer-dependencies.sh
+++ b/deps/softwarecontainer-dependencies.sh
@@ -44,7 +44,7 @@ function install {
 # For softwarecontainer
 install libdbus-c++-dev libdbus-1-dev libglibmm-2.4-dev libglibmm-2.4 \
         unzip bridge-utils lcov libjansson-dev libjansson4 \
-        dbus-x11 libcap-dev
+        dbus-x11 libcap-dev libtool
 
 # Download and install lxc
 git clone git://github.com/lxc/lxc -b stable-2.0


### PR DESCRIPTION
LXC will no longer build without this

Signed-off-by: Jonatan Pålsson <jonatan.palsson@pelagicore.com>