### PR TITLE
Added an optional makecommand argument to the qmake and qt5-git-builder

### DIFF
--- a/build/qmake-git-builder.sh
+++ b/build/qmake-git-builder.sh
@@ -19,11 +19,13 @@
 # 
 # 
 # Usage: qmake-git-builder.sh <srcdir> <gitrepo> <qmakepath> <qmakeargs> \
-#              <.pro file> [revision]
+#              <.pro file> [revision] [make command]
 # 
 # Download git repo containing a qmake build system into srcdir and build 
 # in srcdir/build using qmakeargs to qmake. 
 #
+# The optional make command argument can be used to specify which commands should
+# be executed to build the source code. If nothing is specified it will run: make && sudo make install
 
 srcdir=$1
 builddir=$srcdir/build
@@ -32,6 +34,7 @@ qmakepath=$3
 qmakeargs=$4
 projectfile=$5
 rev=$6
+makecommand=$7
 
 echo "Building $srcdir from git repo $gitrepo"
 
@@ -45,5 +48,9 @@ fi
 mkdir $builddir
 cd $builddir
 $qmakepath ../$projectfile $qmakeargs
-make && sudo make install
+if  [[ "$makecommand" != "" ]] ; then
+    eval "$makecommand"
+else
+    make && sudo make install
+fi
 

--- a/build/qt5-git-builder.sh
+++ b/build/qt5-git-builder.sh
@@ -18,15 +18,18 @@
 # For further information see LICENSE
 # 
 # 
-# Usage: qt5-git-builder.sh <srcdir> <branch> <configure args>
+# Usage: qt5-git-builder.sh <srcdir> <branch> <configure args> [make command]
 # 
 # Download a certain branch of qt5 from git, and build and install.
 #
+# The optional make command argument can be used to specify which commands should
+# be executed to build qt5. If nothing is specified it will run: make && sudo make install
 
 srcdir=$1
 gitrepo="https://github.com/qt/qt5.git"
 branch=$2
 configureargs=$3
+makecommand=$4
 
 echo "Building $srcdir from git repo $gitrepo"
 
@@ -35,5 +38,9 @@ git clone -b $branch $gitrepo $srcdir
 cd $srcdir
 ./init-repository
 ./configure $configureargs
-make -j3 && sudo make install
+if  [[ "$makecommand" != "" ]] ; then
+    eval "$makecommand"
+else
+    make && sudo make install
+fi
 


### PR DESCRIPTION
This is useful as it allows the developer to change the build flags
or commands. E.g. instead of just installing, the developer could also
execute the check target afterwards for running autotests.