### PR TITLE
SC-deps: Checks out specific lxc commit.

### DIFF
--- a/deps/softwarecontainer-dependencies.sh
+++ b/deps/softwarecontainer-dependencies.sh
@@ -49,8 +49,11 @@ install libdbus-c++-dev libdbus-1-dev libglibmm-2.4-dev libglibmm-2.4 \
 # Download and install lxc
 git clone git://github.com/lxc/lxc -b stable-2.0
 cd lxc
-./autogen.sh
 
+# Last known good commit before cgroups v2 issue starts happening on Debian Jessie
+git checkout 798ee9ba238385965c308fa8682d35cbdaeceb35
+
+./autogen.sh
 ./configure --prefix=/usr --enable-capabilities --with-distro=debian
 make
 sudo make install


### PR DESCRIPTION
LXC introduced a possible bug which causes build problems
for softwarecontainer. This checks out the last known working
commit.

Signed-off-by: Tobias Olausson <tobias.olausson@pelagicore.com>