### PR TITLE
sphinx-deps: Upgrade requests module

### DIFF
--- a/deps/sphinx-dependencies.sh
+++ b/deps/sphinx-dependencies.sh
@@ -57,6 +57,7 @@ fi
 
 # Updating
 sudo pip install --upgrade pip
+sudo pip install --upgrade requests
 
 # Install Sphinx (as root)
 sudo pip install Sphinx


### PR DESCRIPTION
The requests module must be updated for Sphinx 1.5, if not, the
following error is seen:

    sphinx-build -b html -d _build/doctrees   . _build/html
    Running Sphinx v1.5
    making output directory...
    Extension error:
    Could not import extension sphinx.builders.linkcheck (exception:
    cannot import name SSLError)

Signed-off-by: Jonatan Pålsson <jonatan.palsson@pelagicore.com>