### PR TITLE
Use -j$(nproc) whenever invoking make

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -35,7 +35,7 @@ Mozilla Public License Version 2.0
     means any form of the work other than Source Code Form.
 
 1.7. "Larger Work"
-    means a work that combines Covered Software with other material, in 
+    means a work that combines Covered Software with other material, in
     a separate file or files, that is not Covered Software.
 
 1.8. "License"

--- a/README.md
+++ b/README.md
@@ -1,30 +1,30 @@
 vagrant-cookbook
 ================
 
-Introduction 
+Introduction
 ------------
 The vagrant cookbook contains a lot of small code snippets that we reuse in
 Vagrantfiles provided for different projects. The general guideline is that the
 snippets should be generic, and use parameters to create code reuse as far as
 possible.
 
-It is worth mentioning that since Pelagicore use Vagrant almost exclusively with 
+It is worth mentioning that since Pelagicore use Vagrant almost exclusively with
 VirtualBox as the virtualization provider, some scripts assume that Virtualbox
 is used as vagrant provider. Most notably when upgrading to debian testing,
 virtualbox-dkms is reinstalled and rebuilt for the new kernel.
 
 Directory Structure
 -------------------
-* build - bash snippets for building software from various source code 
-repositories. 
-* deps - bash snippets for automatically downloading and installing various 
+* build - bash snippets for building software from various source code
+repositories.
+* deps - bash snippets for automatically downloading and installing various
 build/runtime dependencies for common types of work.
-* host-system-config - Vagrant snippets and related bash scripts for configuring 
+* host-system-config - Vagrant snippets and related bash scripts for configuring
 the host systems
 * system-config - various scripts for configuring the host system.
 utils - utility scripts for various tasks.
-* yocto - yocto related utilities used to download tools, setup environments and 
-to build yocto targets. 
+* yocto - yocto related utilities used to download tools, setup environments and
+to build yocto targets.
 
 
 Example usage: Shell scripts

--- a/build/build-documentation.sh
+++ b/build/build-documentation.sh
@@ -1,22 +1,22 @@
 #!/bin/bash
 # vagrant-cookbook
 # Copyright (C) 2015 Pelagicore AB
-#      
-# Permission to use, copy, modify, and/or distribute this software for 
-# any purpose with or without fee is hereby granted, provided that the 
-# above copyright notice and this permission notice appear in all copies. 
-#  
-# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL 
-# WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED  
-# WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR 
-# BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES 
-# OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, 
-# WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, 
-# ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS 
+#
+# Permission to use, copy, modify, and/or distribute this software for
+# any purpose with or without fee is hereby granted, provided that the
+# above copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+# WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR
+# BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES
+# OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+# WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+# ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS
 # SOFTWARE.
-#   
+#
 # For further information see LICENSE
-# 
+#
 
 DOC_DIR=$1
 
@@ -28,9 +28,9 @@ make clean
 
 
 # Not all projects have slides
-make slides
+make -j$(nproc) slides
 
 # Errors are fatal from now on, these targets should always work
 set -e
-make html
-make latexpdf
+make -j$(nproc) html
+make -j$(nproc) latexpdf

--- a/build/clang-code-analysis.sh
+++ b/build/clang-code-analysis.sh
@@ -1,22 +1,22 @@
 #!/bin/bash
 # vagrant-cookbook
 # Copyright (C) 2015 Pelagicore AB
-#      
-# Permission to use, copy, modify, and/or distribute this software for 
-# any purpose with or without fee is hereby granted, provided that the 
-# above copyright notice and this permission notice appear in all copies. 
-#  
-# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL 
-# WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED  
-# WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR 
-# BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES 
-# OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, 
-# WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, 
-# ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS 
+#
+# Permission to use, copy, modify, and/or distribute this software for
+# any purpose with or without fee is hereby granted, provided that the
+# above copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+# WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR
+# BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES
+# OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+# WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+# ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS
 # SOFTWARE.
-#   
+#
 # For further information see LICENSE
-# 
+#
 #
 # Usage: clang-code-analysis.sh <sourcedir> <clangdir> <cmake_args>
 #
@@ -125,5 +125,5 @@ cd $sourcedir/$clangdir
 
 # Build
 scan-build $CHECKERS -o scan_build_output cmake ../ $cmakeargs
-scan-build $CHECKERS -o scan_build_output make
+scan-build $CHECKERS -o scan_build_output make -j$(nproc)
 

--- a/build/cmake-builder.sh
+++ b/build/cmake-builder.sh
@@ -1,26 +1,26 @@
 #!/bin/bash
 # vagrant-cookbook
 # Copyright (C) 2015 Pelagicore AB
-#      
-# Permission to use, copy, modify, and/or distribute this software for 
-# any purpose with or without fee is hereby granted, provided that the 
-# above copyright notice and this permission notice appear in all copies. 
-#  
-# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL 
-# WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED  
-# WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR 
-# BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES 
-# OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, 
-# WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, 
-# ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS 
+#
+# Permission to use, copy, modify, and/or distribute this software for
+# any purpose with or without fee is hereby granted, provided that the
+# above copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+# WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR
+# BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES
+# OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+# WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+# ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS
 # SOFTWARE.
-#   
+#
 # For further information see LICENSE
-# 
-# 
+#
+#
 # Usage: cmake-builder.sh <srcdir> <cmakeargs> <copyflag>
-# 
-# If copyflag is set to true, copy the vagrant directory to the srcdir 
+#
+# If copyflag is set to true, copy the vagrant directory to the srcdir
 # and build, else just build whatever is there directly.
 #
 
@@ -45,5 +45,5 @@ rm -rf $builddir
 mkdir $builddir
 cd $builddir
 cmake .. $cmakeargs
-make && sudo make install
+make -j$(nproc) && sudo make install
 

--- a/build/cmake-git-builder.sh
+++ b/build/cmake-git-builder.sh
@@ -1,27 +1,27 @@
 #!/bin/bash
 # vagrant-cookbook
 # Copyright (C) 2015 Pelagicore AB
-#      
-# Permission to use, copy, modify, and/or distribute this software for 
-# any purpose with or without fee is hereby granted, provided that the 
-# above copyright notice and this permission notice appear in all copies. 
-#  
-# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL 
-# WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED  
-# WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR 
-# BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES 
-# OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, 
-# WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, 
-# ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS 
+#
+# Permission to use, copy, modify, and/or distribute this software for
+# any purpose with or without fee is hereby granted, provided that the
+# above copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+# WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR
+# BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES
+# OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+# WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+# ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS
 # SOFTWARE.
-#   
+#
 # For further information see LICENSE
-# 
-# 
+#
+#
 # Usage: cmake-git-builder.sh <srcdir> <gitrepo> <cmakeargs> [revision]
-# 
-# Download gitrepo containing a cmake build system into srcdir and build 
-# in srcdir/build using cmakeargs to cmake. 
+#
+# Download gitrepo containing a cmake build system into srcdir and build
+# in srcdir/build using cmakeargs to cmake.
 #
 
 srcdir=$1
@@ -42,5 +42,5 @@ fi
 mkdir $builddir
 cd $builddir
 cmake .. $cmakeargs
-make && sudo make install
+make -j$(nproc) && sudo make install
 

--- a/build/qmake-git-builder.sh
+++ b/build/qmake-git-builder.sh
@@ -1,28 +1,28 @@
 #!/bin/bash
 # vagrant-cookbook
 # Copyright (C) 2016 Pelagicore AB
-#      
-# Permission to use, copy, modify, and/or distribute this software for 
-# any purpose with or without fee is hereby granted, provided that the 
-# above copyright notice and this permission notice appear in all copies. 
-#  
-# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL 
-# WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED  
-# WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR 
-# BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES 
-# OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, 
-# WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, 
-# ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS 
+#
+# Permission to use, copy, modify, and/or distribute this software for
+# any purpose with or without fee is hereby granted, provided that the
+# above copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+# WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR
+# BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES
+# OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+# WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+# ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS
 # SOFTWARE.
-#   
+#
 # For further information see LICENSE
-# 
-# 
+#
+#
 # Usage: qmake-git-builder.sh <srcdir> <gitrepo> <qmakepath> <qmakeargs> \
 #              <.pro file> [revision] [make command]
-# 
-# Download git repo containing a qmake build system into srcdir and build 
-# in srcdir/build using qmakeargs to qmake. 
+#
+# Download git repo containing a qmake build system into srcdir and build
+# in srcdir/build using qmakeargs to qmake.
 #
 # The optional make command argument can be used to specify which commands should
 # be executed to build the source code. If nothing is specified it will run: make && sudo make install
@@ -51,6 +51,6 @@ $qmakepath ../$projectfile $qmakeargs
 if  [[ "$makecommand" != "" ]] ; then
     eval "$makecommand"
 else
-    make && sudo make install
+    make -j$(nproc) && sudo make install
 fi
 

--- a/build/qt5-git-builder.sh
+++ b/build/qt5-git-builder.sh
@@ -1,25 +1,25 @@
 #!/bin/bash
 # vagrant-cookbook
 # Copyright (C) 2016 Pelagicore AB
-#      
-# Permission to use, copy, modify, and/or distribute this software for 
-# any purpose with or without fee is hereby granted, provided that the 
-# above copyright notice and this permission notice appear in all copies. 
-#  
-# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL 
-# WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED  
-# WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR 
-# BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES 
-# OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, 
-# WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, 
-# ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS 
+#
+# Permission to use, copy, modify, and/or distribute this software for
+# any purpose with or without fee is hereby granted, provided that the
+# above copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+# WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR
+# BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES
+# OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+# WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+# ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS
 # SOFTWARE.
-#   
+#
 # For further information see LICENSE
-# 
-# 
+#
+#
 # Usage: qt5-git-builder.sh <srcdir> <branch> <configure args> [make command]
-# 
+#
 # Download a certain branch of qt5 from git, and build and install.
 #
 # The optional make command argument can be used to specify which commands should
@@ -41,6 +41,6 @@ cd $srcdir
 if  [[ "$makecommand" != "" ]] ; then
     eval "$makecommand"
 else
-    make && sudo make install
+    make -j$(nproc) && sudo make install
 fi
 

--- a/deps/softwarecontainer-dependencies.sh
+++ b/deps/softwarecontainer-dependencies.sh
@@ -52,5 +52,5 @@ cd lxc
 
 ./autogen.sh
 ./configure --prefix=/usr --enable-capabilities --with-distro=debian
-make
+make -j$(nproc)
 sudo make install


### PR DESCRIPTION
nproc is part of coreutils and will hence always be available, and it is
a bit wasteful not to use parallelism where we can.

Also removed trailing whitespace in some files.

Signed-off-by: Tobias Olausson <tobias.olausson@pelagicore.com>