### PR TITLE
Enable swapaccount option to use cgroup swap extension

### DIFF
--- a/system-config/grub-enable-cgroup-memory.sh
+++ b/system-config/grub-enable-cgroup-memory.sh
@@ -22,6 +22,6 @@
 #
 
 if [ -z "$(grep "cgroup_enable=memory quiet" /etc/default/grub)" ]; then
-	sed -i '/GRUB_CMDLINE_LINUX_DEFAULT=/c \GRUB_CMDLINE_LINUX_DEFAULT=\"cgroup_enable=memory quiet\"' /etc/default/grub
+	sed -i '/GRUB_CMDLINE_LINUX_DEFAULT=/c \GRUB_CMDLINE_LINUX_DEFAULT=\"cgroup_enable=memory swapaccount=1 quiet\"' /etc/default/grub
 	update-grub
 fi


### PR DESCRIPTION
This is necessary for using swap extension of cgroup (). 
I.e. to be able to use following :
- memory.memsw.failcnt
- memory.memsw.limit_in_bytes
- memory.memsw.max_usage_in_bytes
- memory.memsw.usage_in_bytes