### PR TITLE
Add Clang as developer convenience

### DIFF
--- a/deps/developer-tools.sh
+++ b/deps/developer-tools.sh
@@ -57,3 +57,6 @@ install tcpdump
 
 # shell
 install zsh
+
+# Compilers
+install clang


### PR DESCRIPTION
Add Clang to be installed when installing developer convenience.

Signed-off-by: Viktor Sjölind <viktor.sjolind@pelagicore.com>