### PR TITLE
deps/yocto.sh: Add qemu-user

### DIFF
--- a/deps/yocto.sh
+++ b/deps/yocto.sh
@@ -43,5 +43,5 @@ sudo apt-get update
 install git sed wget cvs subversion git-core                            \
     coreutils unzip gawk python-pysqlite2 diffstat help2man make gcc    \
     build-essential g++ chrpath libxml2-utils libsdl1.2-dev texinfo     \
-    python3 graphviz
+    python3 graphviz qemu-user
 


### PR DESCRIPTION
If this is not installed, you may see errors like the following:

(/home/vagrant/drivecx_yocto/sources/poky/meta/recipes-gnome/gobject-introspection/gobject-introspection_1.46.0.bb,
do_compile) failed with exit code '1'==> default: | /home/vagrant/drivecx_yocto/build/tmp/work/aarch64-gnu-linux/gobject-introspection/1.46.0-r0/build/g-ir-scanner-qemuwrapper: 6: /home/vagrant/drivecx_yocto/build/tmp/work/aarch64-gnu-linux/gobject-introspection/1.46.0-r0/build/g-ir-scanner-qemuwrapper: /home/vagrant/drivecx_yocto/build/tmp/work/aarch64-gnu-linux/gobject-introspection/1.46.0-r0/build/g-ir-scanner-qemuwrapper: 6: /home/vagrant/drivecx_yocto/build/tmp/work/aarch64-gnu-linux/gobject-introspection/1.46.0-r0/build/g-ir-scanner-qemuwrapper: /home/vagrant/drivecx_yocto/build/tmp/work/aarch64-gnu-linux/gobject-introspection/1.46.0-r0/build/g-ir-scanner-qemuwrapper: 6: /home/vagrant/drivecx_yocto/build/tmp/work/aarch64-gnu-linux/gobject-introspection/1.46.0-r0/build/g-ir-scanner-qemuwrapper: qemu-aarch64: not found
==> default: | If the above error message is about missing .so libraries, then setting up GIR_EXTRA_LIBS_PATH in the recipe should help.
==> default: | (typically like this: GIR_EXTRA_LIBS_PATH="${B}/something/.libs" )
==> default: | qemu-aarch64: not found
==> default: | Makefile:3476: recipe for target 'gir/fontconfig-2.0.typelib' failed
==> default: | If the above error message is about missing .so libraries, then setting up GIR_EXTRA_LIBS_PATH in the recipe should help.
==> default: | make[2]: *** [gir/fontconfig-2.0.typelib] Error 1
==> default: | (typically like this: GIR_EXTRA_LIBS_PATH="${B}/something/.libs" )
==> default: | make[2]: *** Waiting for unfinished jobs....
==> default: | Makefile:3476: recipe for target 'gir/libxml2-2.0.typelib' failed
==> default: | make[2]: *** [gir/libxml2-2.0.typelib] Error 1
==> default: | qemu-aarch64: not found
==> default: | If the above error message is about missing .so libraries, then setting up GIR_EXTRA_LIBS_PATH in the recipe should help.
==> default: | (typically like this: GIR_EXTRA_LIBS_PATH="${B}/something/.libs" )
==> default: | Makefile:3476: recipe for target 'gir/freetype2-2.0.typelib' failed
==> default: | make[2]: *** [gir/freetype2-2.0.typelib] Error 1
==> default: | /home/vagrant/drivecx_yocto/build/tmp/work/aarch64-gnu-linux/gobject-introspection/1.46.0-r0/build/g-ir-scanner-qemuwrapper: 6: /home/vagrant/drivecx_yocto/build/tmp/work/aarch64-gnu-linux/gobject-introspection/1.46.0-r0/build/g-ir-scanner-qemuwrapper: qemu-aarch64: not found
==> default: | If the above error message is about missing .so libraries, then setting up GIR_EXTRA_LIBS_PATH in the recipe should help.
==> default: | (typically like this: GIR_EXTRA_LIBS_PATH="${B}/something/.libs" )
==> default: | Makefile:3476: recipe for target 'gir/DBus-1.0.typelib' failed
==> default: | make[2]: *** [gir/DBus-1.0.typelib] Error 1
==> default: | /home/vagrant/drivecx_yocto/build/tmp/work/aarch64-gnu-linux/gobject-introspection/1.46.0-r0/build/g-ir-scanner-qemuwrapper: 6: /home/vagrant/drivecx_yocto/build/tmp/work/aarch64-gnu-linux/gobject-introspection/1.46.0-r0/build/g-ir-scanner-qemuwrapper: qemu-aarch64: not found
==> default: | If the above error message is about missing .so libraries, then setting up GIR_EXTRA_LIBS_PATH in the recipe should help.
==> default: | (typically like this: GIR_EXTRA_LIBS_PATH="${B}/som
==> default: ething/.libs" )
==> default: | Makefile:3476: recipe for target 'gir/GL-1.0.typelib' failed
==> default: | make[2]: *** [gir/GL-1.0.typelib] Error 1
==> default: | g-ir-scanner: link: ./aarch64-gnu-linux-libtool --mode=link --tag=CC aarch64-gnu-linux-gcc -fno-omit-frame-pointer -march=armv8-a+crypto -mtune=cortex-a57 -funwind-tables --sysroot=/home/vagrant/drivecx_yocto/build/tmp/sysroots/tegra-t18x -o /home/vagrant/drivecx_yocto/build/tmp/work/aarch64-gnu-linux/gobject-introspection/1.46.0-r0/build/tmp-introspectXTpfz2/GLib-2.0 -export-dynamic -fno-strict-aliasing -Wsign-compare -Wcast-align -Wpointer-arith -Wnested-externs -Wmissing-prototypes -Wmissing-declarations -Wchar-subscripts -Wall -O2 -pipe -g -feliminate-unused-debug-types -fdebug-prefix-map=/home/vagrant/drivecx_yocto/build/tmp/work/aarch64-gnu-linux/gobject-introspection/1.46.0-r0=/usr/src/debug/gobject-introspection/1.46.0-r0 -fdebug-prefix-map=/home/vagrant/drivecx_yocto/build/tmp/sysroots/x86_64-linux= -fdebug-prefix-map=/home/vagrant/drivecx_yocto/build/tmp/sysroots/tegra-t18x= -Wl,-O1 -Wl,--hash-style=gnu -Wl,--as-needed tmp-introspectXTpfz2/home/vagrant/drivecx_yocto/build/tmp/work/aarch64-gnu-linux/gobject-introspection/1.46.0-r0/build/tmp-introspectXTpfz2/GLib-2.0.o -lgio-2.0 -lgobject-2.0 -Wl,--export-dynamic -lgmodule-2.0 -pthread -lglib-2.0 -lglib-2.0 -lgobject-2.0
==> default: | aarch64-gnu-linux-libtool: link: aarch64-gnu-linux-gcc -fno-omit-frame-pointer -march=armv8-a+crypto -mtune=cortex-a57 -funwind-tables --sysroot=/home/vagrant/drivecx_yocto/build/tmp/sysroots/tegra-t18x -o /home/vagrant/drivecx_yocto/build/tmp/work/aarch64-gnu-linux/gobject-introspection/1.46.0-r0/build/tmp-introspectXTpfz2/GLib-2.0 -fno-strict-aliasing -Wsign-compare -Wcast-align -Wpointer-arith -Wnested-externs -Wmissing-prototypes -Wmissing-declarations -Wchar-subscripts -Wall -O2 -pipe -g -feliminate-unused-debug-types -fdebug-prefix-map=/home/vagrant/drivecx_yocto/build/tmp/work/aarch64-gnu-linux/gobject-introspection/1.46.0-r0=/usr/src/debug/gobject-introspection/1.46.0-r0 -fdebug-prefix-map=/home/vagrant/drivecx_yocto/build/tmp/sysroots/x86_64-linux= -fdebug-prefix-map=/home/vagrant/drivecx_yocto/build/tmp/sysroots/tegra-t18x= -Wl,-O1 -Wl,--hash-style=gnu -Wl,--as-needed tmp-introspectXTpfz2/home/vagrant/drivecx_yocto/build/tmp/work/aarch64-gnu-linux/gobject-introspection/1.46.0-r0/build/tmp-introspectXTpfz2/GLib-2.0.o -Wl,--export-dynamic -pthread -Wl,--export-dynamic  /home/vagrant/drivecx_yocto/build/tmp/sysroots/tegra-t18x/usr/lib/libgio-2.0.so -lz -lresolv /home/vagrant/drivecx_yocto/build/tmp/sysroots/tegra-t18x/usr/lib/libgmodule-2.0.so -ldl /home/vagrant/drivecx_yocto/build/tmp/sysroots/tegra-t18x/usr/lib/libgobject-2.0.so /home/vagrant/drivecx_yocto/build/tmp/sysroots/tegra-t18x/usr/lib/libglib-2.0.so /home/vagrant/drivecx_yocto/build/tmp/sysroots/tegra-t18x/usr/lib/libpcre.so -lpthread /home/vagrant/drivecx_yocto/build/tmp/sysroots/tegra-t18x/usr/lib/libffi.so -pthread
==> default: | /home/vagrant/drivecx_yocto/build/tmp/work/aarch64-gnu-linux/gobject-introspection/1.46.0-r0/build/g-ir-scanner-qemuwrapper: 6: /home/vagrant/drivecx_yocto/build/tmp/work/aarch64-gnu-linux/gobject-introspection/1.46.0-r0/build/g-ir-scanner-qemuwrapper: qemu-aarch64: not found
==> default: | If the above error message is about missing .so libraries, then setting up GIR_EXTRA_LIBS_PATH in the recipe should help.
==> default: | (typically like this: GIR_EXTRA_LIBS_PATH="${B}/something/.libs" )
==> default: | Command '['/home/vagrant/drivecx_yocto/build/tmp/work/aarch64-gnu-linux/gobject-introspection/1.46.0-r0/build/g-ir-scanner-qemuwrapper', '/home/vagrant/drivecx_yocto/build/tmp/work/aarch64-gnu-linux/gobject-introspection/1.46.0-r0/build/tmp-introspectXTpfz2/GLib-2.0', '--introspect-dump=/home/vagrant/drivecx_yocto/build/tmp/work/aarch64-gnu-linux/gobject-introspection/1.46.0-r0/build/tmp-introspectXTpfz2/functions.txt,/home/vagrant/drivecx_yocto/build/tmp/work/aarch64-gnu-linux/gobject-introspection/1.46.0-r0/build/tmp-introspectXTpfz2/dump.xml']' returned non-zero exit status 1
==> default: | Makefile:3463: recipe for target 'GLib-2.0.gir' failed
==> default: | make[2]: *** [GLib-2.0.gir] Error 1
==> default: | make[2]: Leaving directory '/home/vagrant/drivecx_yocto/build/tmp/work/aarch64-gnu-linux/gobject-introspection/1.46.0-r0/build'
==> default: | Makefile:2754: recipe for target 'all-recursive' failed
==> default: | make[1]: *** [all-recursive] Error 1
==> default: | make[1]: Leaving directory '/home/vagrant/drivecx_yocto/build/tmp/work/aarch64-gnu-linux/gobject-introspection/1.46.0-r0/build'
==> default: | Makefile:1533: recipe for target 'all' failed
==> default: | make: *** [all] Error 2
==> default: | WARNING: exit code 1 from a shell command.
==> default: | ERROR: oe_runmake failed
==> default: | ERROR: Function failed: do_compile (log file is located at /home/vagrant/drivecx_yocto/build/tmp/work/aarch64-gnu-linux/gobject-introspection/1.46.0-r0/temp/log.do_compile.22351)
==> default: NOTE: recipe gobject-introspection-1.46.0-r0: task do_compile: Failed
==> default: ERROR: Task 1607 (/home/vagrant/drivecx_yocto/sources/poky/meta/recipes-gnome/gobject-introspection/gobject-introspection_1.46.0.bb, do_compile) failed with exit code '1'==> default: | /home/vagrant/drivecx_yocto/build/tmp/work/aarch64-gnu-linux/gobject-introspection/1.46.0-r0/build/g-ir-scanner-qemuwrapper: 6: /home/vagrant/drivecx_yocto/build/tmp/work/aarch64-gnu-linux/gobject-introspection/1.46.0-r0/build/g-ir-scanner-qemuwrapper: /home/vagrant/drivecx_yocto/build/tmp/work/aarch64-gnu-linux/gobject-introspection/1.46.0-r0/build/g-ir-scanner-qemuwrapper: 6: /home/vagrant/drivecx_yocto/build/tmp/work/aarch64-gnu-linux/gobject-introspection/1.46.0-r0/build/g-ir-scanner-qemuwrapper: /home/vagrant/drivecx_yocto/build/tmp/work/aarch64-gnu-linux/gobject-introspection/1.46.0-r0/build/g-ir-scanner-qemuwrapper: 6: /home/vagrant/drivecx_yocto/build/tmp/work/aarch64-gnu-linux/gobject-introspection/1.46.0-r0/build/g-ir-scanner-qemuwrapper: qemu-aarch64: not found
==> default: | If the above error message is about missing .so libraries, then setting up GIR_EXTRA_LIBS_PATH in the recipe should help.
==> default: | (typically like this: GIR_EXTRA_LIBS_PATH="${B}/something/.libs" )
==> default: | qemu-aarch64: not found
==> default: | Makefile:3476: recipe for target 'gir/fontconfig-2.0.typelib' failed
==> default: | If the above error message is about missing .so libraries, then setting up GIR_EXTRA_LIBS_PATH in the recipe should help.
==> default: | make[2]: *** [gir/fontconfig-2.0.typelib] Error 1
==> default: | (typically like this: GIR_EXTRA_LIBS_PATH="${B}/something/.libs" )
==> default: | make[2]: *** Waiting for unfinished jobs....
==> default: | Makefile:3476: recipe for target 'gir/libxml2-2.0.typelib' failed
==> default: | make[2]: *** [gir/libxml2-2.0.typelib] Error 1
==> default: | qemu-aarch64: not found
==> default: | If the above error message is about missing .so libraries, then setting up GIR_EXTRA_LIBS_PATH in the recipe should help.
==> default: | (typically like this: GIR_EXTRA_LIBS_PATH="${B}/something/.libs" )
==> default: | Makefile:3476: recipe for target 'gir/freetype2-2.0.typelib' failed
==> default: | make[2]: *** [gir/freetype2-2.0.typelib] Error 1
==> default: | /home/vagrant/drivecx_yocto/build/tmp/work/aarch64-gnu-linux/gobject-introspection/1.46.0-r0/build/g-ir-scanner-qemuwrapper: 6: /home/vagrant/drivecx_yocto/build/tmp/work/aarch64-gnu-linux/gobject-introspection/1.46.0-r0/build/g-ir-scanner-qemuwrapper: qemu-aarch64: not found
==> default: | If the above error message is about missing .so libraries, then setting up GIR_EXTRA_LIBS_PATH in the recipe should help.
==> default: | (typically like this: GIR_EXTRA_LIBS_PATH="${B}/something/.libs" )
==> default: | Makefile:3476: recipe for target 'gir/DBus-1.0.typelib' failed
==> default: | make[2]: *** [gir/DBus-1.0.typelib] Error 1
==> default: | /home/vagrant/drivecx_yocto/build/tmp/work/aarch64-gnu-linux/gobject-introspection/1.46.0-r0/build/g-ir-scanner-qemuwrapper: 6: /home/vagrant/drivecx_yocto/build/tmp/work/aarch64-gnu-linux/gobject-introspection/1.46.0-r0/build/g-ir-scanner-qemuwrapper: qemu-aarch64: not found
==> default: | If the above error message is about missing .so libraries, then setting up GIR_EXTRA_LIBS_PATH in the recipe should help.
==> default: | (typically like this: GIR_EXTRA_LIBS_PATH="${B}/som
==> default: ething/.libs" )
==> default: | Makefile:3476: recipe for target 'gir/GL-1.0.typelib' failed
==> default: | make[2]: *** [gir/GL-1.0.typelib] Error 1
==> default: | g-ir-scanner: link: ./aarch64-gnu-linux-libtool --mode=link --tag=CC aarch64-gnu-linux-gcc -fno-omit-frame-pointer -march=armv8-a+crypto -mtune=cortex-a57 -funwind-tables --sysroot=/home/vagrant/drivecx_yocto/build/tmp/sysroots/tegra-t18x -o /home/vagrant/drivecx_yocto/build/tmp/work/aarch64-gnu-linux/gobject-introspection/1.46.0-r0/build/tmp-introspectXTpfz2/GLib-2.0 -export-dynamic -fno-strict-aliasing -Wsign-compare -Wcast-align -Wpointer-arith -Wnested-externs -Wmissing-prototypes -Wmissing-declarations -Wchar-subscripts -Wall -O2 -pipe -g -feliminate-unused-debug-types -fdebug-prefix-map=/home/vagrant/drivecx_yocto/build/tmp/work/aarch64-gnu-linux/gobject-introspection/1.46.0-r0=/usr/src/debug/gobject-introspection/1.46.0-r0 -fdebug-prefix-map=/home/vagrant/drivecx_yocto/build/tmp/sysroots/x86_64-linux= -fdebug-prefix-map=/home/vagrant/drivecx_yocto/build/tmp/sysroots/tegra-t18x= -Wl,-O1 -Wl,--hash-style=gnu -Wl,--as-needed tmp-introspectXTpfz2/home/vagrant/drivecx_yocto/build/tmp/work/aarch64-gnu-linux/gobject-introspection/1.46.0-r0/build/tmp-introspectXTpfz2/GLib-2.0.o -lgio-2.0 -lgobject-2.0 -Wl,--export-dynamic -lgmodule-2.0 -pthread -lglib-2.0 -lglib-2.0 -lgobject-2.0
==> default: | aarch64-gnu-linux-libtool: link: aarch64-gnu-linux-gcc -fno-omit-frame-pointer -march=armv8-a+crypto -mtune=cortex-a57 -funwind-tables --sysroot=/home/vagrant/drivecx_yocto/build/tmp/sysroots/tegra-t18x -o /home/vagrant/drivecx_yocto/build/tmp/work/aarch64-gnu-linux/gobject-introspection/1.46.0-r0/build/tmp-introspectXTpfz2/GLib-2.0 -fno-strict-aliasing -Wsign-compare -Wcast-align -Wpointer-arith -Wnested-externs -Wmissing-prototypes -Wmissing-declarations -Wchar-subscripts -Wall -O2 -pipe -g -feliminate-unused-debug-types -fdebug-prefix-map=/home/vagrant/drivecx_yocto/build/tmp/work/aarch64-gnu-linux/gobject-introspection/1.46.0-r0=/usr/src/debug/gobject-introspection/1.46.0-r0 -fdebug-prefix-map=/home/vagrant/drivecx_yocto/build/tmp/sysroots/x86_64-linux= -fdebug-prefix-map=/home/vagrant/drivecx_yocto/build/tmp/sysroots/tegra-t18x= -Wl,-O1 -Wl,--hash-style=gnu -Wl,--as-needed tmp-introspectXTpfz2/home/vagrant/drivecx_yocto/build/tmp/work/aarch64-gnu-linux/gobject-introspection/1.46.0-r0/build/tmp-introspectXTpfz2/GLib-2.0.o -Wl,--export-dynamic -pthread -Wl,--export-dynamic  /home/vagrant/drivecx_yocto/build/tmp/sysroots/tegra-t18x/usr/lib/libgio-2.0.so -lz -lresolv /home/vagrant/drivecx_yocto/build/tmp/sysroots/tegra-t18x/usr/lib/libgmodule-2.0.so -ldl /home/vagrant/drivecx_yocto/build/tmp/sysroots/tegra-t18x/usr/lib/libgobject-2.0.so /home/vagrant/drivecx_yocto/build/tmp/sysroots/tegra-t18x/usr/lib/libglib-2.0.so /home/vagrant/drivecx_yocto/build/tmp/sysroots/tegra-t18x/usr/lib/libpcre.so -lpthread /home/vagrant/drivecx_yocto/build/tmp/sysroots/tegra-t18x/usr/lib/libffi.so -pthread
==> default: | /home/vagrant/drivecx_yocto/build/tmp/work/aarch64-gnu-linux/gobject-introspection/1.46.0-r0/build/g-ir-scanner-qemuwrapper: 6: /home/vagrant/drivecx_yocto/build/tmp/work/aarch64-gnu-linux/gobject-introspection/1.46.0-r0/build/g-ir-scanner-qemuwrapper: qemu-aarch64: not found
==> default: | If the above error message is about missing .so libraries, then setting up GIR_EXTRA_LIBS_PATH in the recipe should help.
==> default: | (typically like this: GIR_EXTRA_LIBS_PATH="${B}/something/.libs" )
==> default: | Command '['/home/vagrant/drivecx_yocto/build/tmp/work/aarch64-gnu-linux/gobject-introspection/1.46.0-r0/build/g-ir-scanner-qemuwrapper', '/home/vagrant/drivecx_yocto/build/tmp/work/aarch64-gnu-linux/gobject-introspection/1.46.0-r0/build/tmp-introspectXTpfz2/GLib-2.0', '--introspect-dump=/home/vagrant/drivecx_yocto/build/tmp/work/aarch64-gnu-linux/gobject-introspection/1.46.0-r0/build/tmp-introspectXTpfz2/functions.txt,/home/vagrant/drivecx_yocto/build/tmp/work/aarch64-gnu-linux/gobject-introspection/1.46.0-r0/build/tmp-introspectXTpfz2/dump.xml']' returned non-zero exit status 1
==> default: | Makefile:3463: recipe for target 'GLib-2.0.gir' failed
==> default: | make[2]: *** [GLib-2.0.gir] Error 1
==> default: | make[2]: Leaving directory '/home/vagrant/drivecx_yocto/build/tmp/work/aarch64-gnu-linux/gobject-introspection/1.46.0-r0/build'
==> default: | Makefile:2754: recipe for target 'all-recursive' failed
==> default: | make[1]: *** [all-recursive] Error 1
==> default: | make[1]: Leaving directory '/home/vagrant/drivecx_yocto/build/tmp/work/aarch64-gnu-linux/gobject-introspection/1.46.0-r0/build'
==> default: | Makefile:1533: recipe for target 'all' failed
==> default: | make: *** [all] Error 2
==> default: | WARNING: exit code 1 from a shell command.
==> default: | ERROR: oe_runmake failed
==> default: | ERROR: Function failed: do_compile (log file is located at /home/vagrant/drivecx_yocto/build/tmp/work/aarch64-gnu-linux/gobject-introspection/1.46.0-r0/temp/log.do_compile.22351)
==> default: NOTE: recipe gobject-introspection-1.46.0-r0: task do_compile: Failed
==> default: ERROR: Task 1607 (/home/vagrant/drivecx_yocto/sources/poky/meta/recipes-gnome/gobject-introspection/gobject-introspection_1.46.0.bb, do_compile) failed with exit code '1'