### PR TITLE
Remove alpha.unix.MallocWithAnnotations as it's not available

### DIFF
--- a/build/clang-code-analysis.sh
+++ b/build/clang-code-analysis.sh
@@ -49,7 +49,6 @@ CHECKERS="-enable-checker alpha.core.BoolAssignment\
     -enable-checker alpha.security.ReturnPtrRange\
     -enable-checker alpha.security.taint.TaintPropagation\
     -enable-checker alpha.unix.Chroot\
-    -enable-checker alpha.unix.MallocWithAnnotations\
     -enable-checker alpha.unix.PthreadLock\
     -enable-checker alpha.unix.SimpleStream\
     -enable-checker alpha.unix.Stream\


### PR DESCRIPTION
Signed-off-by: Oscar Andreasson <oscar.andreasson@pelagicore.com>