### PR TITLE
Update so we don't download old binaries

### DIFF
--- a/system-config/select-apt-mirror.sh
+++ b/system-config/select-apt-mirror.sh
@@ -53,6 +53,8 @@ if [ -e "sources.list" ]; then
     rm sources.list
 fi
 
+apt-get update
+
 install netselect-apt
 sudo netselect-apt -f -s -o sources.list $releaseName
 mv sources.list /etc/apt/sources.list


### PR DESCRIPTION
If we try to download old packages that don't exist we will wind up with a broken Vagrantfile

Signed-off-by: Oscar Andreasson <oscar.andreasson@pelagicore.com>