### PR TITLE
pytest deps: order of pip/pip3 install matters.

### DIFF
--- a/deps/pytest-and-dbus-testing-dependencies.sh
+++ b/deps/pytest-and-dbus-testing-dependencies.sh
@@ -48,10 +48,11 @@ function install {
 install python3-dbus python3-pip
 install python-gobject python-dbus python-pip
 
+pip install pydbus
+pip install pytest
+pip install psutil
+
 pip3 install pydbus
 pip3 install pytest
 pip3 install psutil
 
-pip install pydbus
-pip install pytest
-pip install psutil


### PR DESCRIPTION
With this change we prefer python3 over python2

Signed-off-by: Tobias Olausson <tobias.olausson@pelagicore.com>