### PR TITLE
Fix procedures execution order in runquemu-smoke-tests.sh

### DIFF
--- a/yocto/runquemu-smoke-test.sh
+++ b/yocto/runquemu-smoke-test.sh
@@ -36,11 +36,11 @@ source oe-init-build-env ../../build
 # A positive exit code from now on is fatal
 set -e
 
-# Set up networking for qemu
-sudo ../sources/poky/scripts/runqemu-gen-tapdevs 1000 1000 4 tmp/sysroots-components/x86_64/qemu-helper-native/usr/bin
-
 # Make sure we have the required utilities
 bitbake qemu-helper-native
+
+# Set up networking for qemu
+sudo ../sources/poky/scripts/runqemu-gen-tapdevs 1000 1000 4 tmp/sysroots-components/x86_64/qemu-helper-native/usr/bin
 
 # Give qemu permissions to access tun interfaces
 sudo setcap cap_net_admin+ep $(find tmp/work/ -name qemu-system-x86_64 | grep qemu-helper-native)


### PR DESCRIPTION
Since we need to have tunctl in our sysroot before running runqemu-gen-tapdevs,
bitbake qemu-helper-native should be executed first.