### PR TITLE
Use set -ex to have verbose print

### DIFF
--- a/yocto/shortlog.sh
+++ b/yocto/shortlog.sh
@@ -29,7 +29,7 @@ SOURCE_CODE_ROOT="$3"
 BRANCH=${4:-origin/master}
 
 # A positive exit code from now on is fatal
-set -e
+set -ex
 
 # Get git shortlog for each meta layer if there is any changes of the revision
 get_changes() {


### PR DESCRIPTION
Still keep -e since it will exit as soon as any line in the script fails

Signed-off-by: Chuan Jin <cjin@luxoft.com>