### PR TITLE
Add support to building the extensible sdk

### DIFF
--- a/yocto/build-esdk.sh
+++ b/yocto/build-esdk.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# vagrant-cookbook
+# Copyright (C) 2015 Pelagicore AB
+#      
+# Permission to use, copy, modify, and/or distribute this software for 
+# any purpose with or without fee is hereby granted, provided that the 
+# above copyright notice and this permission notice appear in all copies. 
+#  
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL 
+# WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED  
+# WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR 
+# BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES 
+# OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, 
+# WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, 
+# ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS 
+# SOFTWARE.
+#   
+# For further information see LICENSE
+# 
+
+YOCTO_DIR="$1"
+IMAGES="$2"
+
+echo "Building Build an SDK for $IMAGES in $YOCTO_DIR"
+
+# Set up bitbake environment
+cd "$YOCTO_DIR/sources/poky/"
+source oe-init-build-env ../../build
+
+# A positive exit code from now on is fatal
+set -e
+
+# Start build
+time bitbake -c populate_sdk_ext $IMAGES


### PR DESCRIPTION
The extensible sdk is being pushed from yocto and Intel to make developing in yocto more accessible. 