### PR TITLE
muxpi: add scripts for flashing and testing RPI

### DIFF
--- a/muxpi/rpi/dut.sh
+++ b/muxpi/rpi/dut.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# Copyright (C) 2018 Luxoft Sweden AB
+#
+# Permission to use, copy, modify, and/or distribute this software for
+# any purpose with or without fee is hereby granted, provided that the
+# above copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+# WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR
+# BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES
+# OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+# WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+# ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS
+# SOFTWARE.
+#
+# For further information see LICENSE
+#
+# This script runs the flashed image on RPI and verifies that the image 
+# is running or degraded.  
+# This script must be called from `set-up-image.sh` on muxpi. 
+#
+# Usage: 
+# ./dut.sh 
+
+set -e
+rm -f $HOME/serial-output
+echo "Setting up DUT" 
+
+# Clear muxpi display and print 'DUT'
+
+stm_armv7 -clr #clear display
+stm_armv7 -print "DUT"
+
+# Make the SD card adapter emulate a real SD-card. Note that the SD card wont be visible on muxpi when its on DUT mode.
+
+stm_armv7 -dut
+echo "RPI booting..."
+sleep 35s
+echo "Starting UART screens..."
+
+stty -F /dev/ttyACM0 115200 cs8 -cstopb -parenb
+
+# We need one screen to save the output of /dev/ttyACM0. Everything will be
+# saved on 'serial-output'
+
+screen -d -m -S output 
+screen -S output -X stuff "cat /dev/ttyACM0 > ${HOME}/serial-output\n" 
+sleep 3s
+
+# This screen will be logging in the rpi and sending the commands to it.
+# Note that when logging in, '\n' has to be passed multiple times as the 
+# login might fail. 
+
+screen -d -m -S input /dev/ttyACM0 115200 
+screen -S input -X stuff '\nroot\n\n\n'
+sleep 5s
+
+# This returns either degraded or running. If it doesnt return either one, then
+# something is wrong and rpi did not boot. This can be later grepped from
+# `serial-output`
+
+screen -S input -X stuff '\n\n\n systemctl is-system-running --wait\n'
+
+sleep 5s
+
+# Kill both of the screens as our job is done. 
+
+screen -X -S input kill
+screen -X -S output kill
+
+
+sleep 5s
+
+# Make the SD card visible on muxpi. (Opposite of stm_armv7 -dut)
+
+stm_armv7 -ts #test server 
+
+# Clear muxpi display and print 'Ready!'
+
+stm_armv7 -clr #clear
+stm_armv7 -print "Ready!"

--- a/muxpi/rpi/set-up-image.sh
+++ b/muxpi/rpi/set-up-image.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+
+# Copyright (C) 2018 Luxoft Sweden AB
+#
+# Permission to use, copy, modify, and/or distribute this software for
+# any purpose with or without fee is hereby granted, provided that the
+# above copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+# WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR
+# BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES
+# OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+# WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+# ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS
+# SOFTWARE.
+#
+# For further information see LICENSE
+#
+# This script downloads, flashes the image and tests it on RPI. 
+# This script must be run on muxpi.
+#
+# Usage: 
+# $ ./set-up-image.sh [neptune]
+# The default image to use is the minimal image. If you want to run the neptune image
+# use the option 'neptune'.
+#
+
+set -e
+
+
+NEPTUNE_IMAGE="$1"
+IMAGES="$HOME/images"
+
+# The url for the latest successful nightly build.
+
+VARIANT_MINIMAL="core-image-pelux-minimal-dev"
+URL_MINIMAL="https://pelux.io/jenkins/job/pelux-manifests_NIGHTLY/lastSuccessfulBuild/artifact/artifacts_rpi/$VARIANT_MINIMAL*/*zip*/artifacts_rpi.zip"
+
+VARIANT_NEPTUNE="core-image-pelux-qtauto-neptune-dev"
+URL_NEPTUNE="https://pelux.io/jenkins/job/pelux-manifests_NIGHTLY/lastSuccessfulBuild/artifact/artifacts_rpi-qtauto/$VARIANT_NEPTUNE*/*zip*/artifacts_rpi-qtauto.zip"
+
+VARIANT=""
+URL=""
+if [ "$NEPTUNE_IMAGE" == neptune ]; then
+   VARIANT=$VARIANT_NEPTUNE
+   URL=$URL_NEPTUNE
+else 
+   VARIANT=$VARIANT_MINIMAL
+   URL=$URL_MINIMAL
+fi
+
+mkdir -p $IMAGES
+
+wget $URL -P $IMAGES
+if [ $? == 0 ]; then
+   echo "Image downloaded"
+fi
+7z x $IMAGES/*.zip -o$IMAGES
+mv $IMAGES/$VARIANT* $IMAGES/$VARIANT
+
+# map.json requires the image names and the number of the partition on SD-card.
+# In our case, we dont need partition numbers, we want the image to be flashed
+# on /dev/sda directly.
+
+echo "{\"${VARIANT}\":\"\"}" > $HOME/map.json
+echo "Json map is ready. Compressing the downloaded image... "
+   
+(cd $IMAGES; tar -czf $VARIANT.tar.gz $VARIANT)
+if [ $? == 0 ]; then
+   echo "Image has finished compressing" 
+fi
+
+# fota requires the card device to be flashed, the json map which contains
+# the image and partitions, and finally the compressed image on tar.gz
+
+fota_armv7 -card /dev/sda -map $HOME/map.json $IMAGES/$VARIANT.tar.gz 
+if [ $? == 0 ];then
+   echo "Image '${VARIANT}' successfully flashed using fota"
+fi
+
+
+echo "Image is set up. Booting up RPI ..."
+
+COUNTER=5
+C=0
+set +e
+
+# When the rpi boots, the login page can behave different 
+# from time to time (serial communication might be a reason).
+# This requires multiple attempts of logging in and sending a message.
+
+while [ $C -lt $COUNTER ]; do
+   let C+=1   
+   echo "Attempt number:" $C " out of " $COUNTER
+   $HOME/scripts/dut.sh
+   grep -r "running" $HOME/serial-output | grep -v is-system-running
+   if [ $? == 0 ]; then
+      echo "Image is successfully running"
+      rm -rf $IMAGES
+      break
+   else
+      grep -r "degraded" $HOME/serial-output
+      if [ $? == 0 ]; then
+         echo "Image is running, but some packages have failed. System status:
+         degraded"
+         rm -rf $IMAGES
+         break
+      else
+         echo "Image booting has failed"
+         echo "--------------------"
+         if [ $(( $C + 1 )) -gt $COUNTER  ]; then
+            set -e 
+            rm -rf $IMAGES
+            exit 1
+         fi	    
+    fi
+fi						       
+done	


### PR DESCRIPTION
set-up-image: This is the main script which downloads the image, makes
it ready for fota, and flashes it via fota. Once its flashed, it calls
dut.sh.

dut.sh: Send the commands to DUT and save the log.

Signed-off-by: Fisnik Hajredini <fhajredini@luxoft.com>