### PR TITLE
shortlog.sh: do not print the manifest diff

### DIFF
--- a/yocto/shortlog.sh
+++ b/yocto/shortlog.sh
@@ -65,7 +65,6 @@ cd $SOURCE_CODE_ROOT
 diff=$(diff -u ${OLD_MANIFEST} $MANIFEST || true)
 if [[ ! -z "${diff// }" ]]
 then
-    printf '%s\n' "$diff"
     cd "$YOCTO_BUILD_DIR"
     # Get the layers used in the build
     for layer in `bitbake-layers show-layers | awk 'NR>2 {print $2}'`


### PR DESCRIPTION
This line was probably there for debugging reasons: any difference
between the manifests is anyway going to be printed in greater detail in
the get_changes() function.