### PR TITLE
pytest-and-dbus-testing-dependencies: install python3-lxc binding

### DIFF
--- a/deps/pytest-and-dbus-testing-dependencies.sh
+++ b/deps/pytest-and-dbus-testing-dependencies.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # vagrant-cookbook
 # Copyright (C) 2015 Pelagicore AB
+# Copyright (C) 2019 Luxoft Sweden AB
 #
 # Permission to use, copy, modify, and/or distribute this software for
 # any purpose with or without fee is hereby granted, provided that the
@@ -45,7 +46,7 @@ function install {
 }
 
 # Install both python2 and python3 versions
-install python3-dbus python3-pip
+install python3-dbus python3-pip python3-lxc
 install python-gobject python-dbus python-pip
 
 pip install pydbus


### PR DESCRIPTION
python3-lxc binding is required to run softwarecontainer service tests.
This binding is required after softwarecontainer is updated to use lxc3
version.

Signed-off-by: Tariq Ansari <tansari@luxoft.com>