### PR TITLE
muxpi/parse_image.sh: Add image file extention

### DIFF
--- a/muxpi/parse_image.sh
+++ b/muxpi/parse_image.sh
@@ -75,7 +75,7 @@ set +e
 set -e
 
 ls $IMAGESPATH
-mv $IMAGESPATH/$VARIANT*rootfs* $IMAGESPATH/$VARIANT
+mv $IMAGESPATH/$VARIANT*rootfs*.wic $IMAGESPATH/$VARIANT
 echo "Compresing \"$VARIANT\"..."
 (cd $IMAGESPATH; tar -czf $VARIANT.tar.gz $VARIANT)
 if [ $? == 0 ]; then


### PR DESCRIPTION
After expanding list of files in archive Mux jobs dont work
To add only image file to archive extention should be added

Signed-off-by: Dmytro Iurchuk <DIurchuk@luxoft.com>