### PR TITLE
yocto: Add optional params to fetch all

### DIFF
--- a/yocto/fetch-sources-for-recipes.sh
+++ b/yocto/fetch-sources-for-recipes.sh
@@ -27,6 +27,8 @@
 
 YOCTO_DIR="$1"
 IMAGES="$2"
+shift 2
+BBARGS="$@" # Optional additional arguments to bitbake
 COUNTER=100
 
 # Set up bitbake environment
@@ -40,7 +42,7 @@ while [ $I -lt $COUNTER ]; do
     echo "Try number: $I"
     let I+=1
     sleep 1
-    time bitbake $IMAGES --runall="fetch"
+    time bitbake $IMAGES --runall="fetch" $BBARGS
     if [ $? -eq 0 ]; then
         break
     fi


### PR DESCRIPTION
Right now it is impossible to pass additional parameters to bitbake
which would change what would be fetched during the fetch phase.
This change takes all aditioal arguments and passes them to bitbake,
this way one can for example add -c populate_sdk which would trigger
fetch for different components then without it.

This change is backwards compatible, it just looks for additional
parameters.