### PR TITLE
Correctly create and use tap devices in runqemu-smoke-test

### DIFF
--- a/yocto/runqemu-smoke-test.sh
+++ b/yocto/runqemu-smoke-test.sh
@@ -42,8 +42,5 @@ bitbake qemu-helper-native
 # Set up networking for qemu
 sudo ../sources/poky/scripts/runqemu-gen-tapdevs `id -u` `id -g` 4 tmp/sysroots-components/x86_64/qemu-helper-native/usr/bin
 
-# Give qemu permissions to access tun interfaces
-sudo setcap cap_net_admin+ep $(find tmp/work/ -name qemu-system-x86_64 | grep qemu-helper-native)
-
 # Start smoke tests
 time bitbake $IMAGES -c testimage

--- a/yocto/runqemu-smoke-test.sh
+++ b/yocto/runqemu-smoke-test.sh
@@ -40,7 +40,7 @@ set -e
 bitbake qemu-helper-native
 
 # Set up networking for qemu
-sudo ../sources/poky/scripts/runqemu-gen-tapdevs 1000 1000 4 tmp/sysroots-components/x86_64/qemu-helper-native/usr/bin
+sudo ../sources/poky/scripts/runqemu-gen-tapdevs `id -u` `id -g` 4 tmp/sysroots-components/x86_64/qemu-helper-native/usr/bin
 
 # Give qemu permissions to access tun interfaces
 sudo setcap cap_net_admin+ep $(find tmp/work/ -name qemu-system-x86_64 | grep qemu-helper-native)


### PR DESCRIPTION
Specifically:

1. do not hardcode uid/gid. Rather use ones actually assigned to the user running the script.

2. do not use setcap. setcap has the unfortunate side effect of no longer loading correct libraries (from qemu sysroot), and instead falling through to host libraries which may mismatch or be absent altogether.
