### PR TITLE
json2junit.py: write the test duration if provided in json

### DIFF
--- a/yocto/json2junit.py
+++ b/yocto/json2junit.py
@@ -73,6 +73,8 @@ class TestSuite:
         tc.setAttribute('name', testcase_name)
         if self.iso_time:
             tc.setAttribute('timestamp', self.iso_time)
+        if 'duration' in result:
+            tc.setAttribute('time', str(result['duration']))
         status = result['status']
         if status == 'FAILED':
             extra = self.doc.createElement('failure')


### PR DESCRIPTION
Recent Yocto versions added support for this, so if the duration
is present it is written into the junit (time is a valid paramer
with the same meaning).

Signed-off-by: Alexander Kanavin <alex.kanavin@gmail.com>