### PR TITLE
yocto/json2unit.py: add timestamp to test case name

### DIFF
--- a/yocto/json2junit.py
+++ b/yocto/json2junit.py
@@ -131,7 +131,7 @@ with open(args.file, 'r') as f:
             assert len(parts) == 3
 
             suite_name = '.'.join(parts[0:2])
-            testcase_name = parts[2]
+            testcase_name = f"{suite_name}_{start_time}"
 
             if suite_name not in suites:
                 suites[suite_name] = TestSuite(suite_name, start_time)


### PR DESCRIPTION
Without this, the resulting report cannot distinguish between different runs for the same test case

This causes xunit reports to be wrongly displayed in Jenkins because it cannot distinguish different runs for the same test case when they have the same name. Then, tests reports are displayed in random order, and when you click a specific report you might get the wrong one.