### PR TITLE
yocto/json2unit.py: hotfix wrong variable used in testcase_name

### DIFF
--- a/yocto/json2junit.py
+++ b/yocto/json2junit.py
@@ -131,7 +131,7 @@ with open(args.file, 'r') as f:
             assert len(parts) == 3
 
             suite_name = '.'.join(parts[0:2])
-            testcase_name = f"{suite_name}_{start_time}"
+            testcase_name = f"{parts[2]}_{start_time}"
 
             if suite_name not in suites:
                 suites[suite_name] = TestSuite(suite_name, start_time)


### PR DESCRIPTION
On the previous PR (https://github.com/Pelagicore/vagrant-cookbook/pull/107) I had mistakenly pushed a commit-amend to the opened PR with the wrong var used. (really sorry for that)

The original change was supposed to be only the addition of `start_time` to the `testcase_name`

This restores the part that was wrong.