### PR TITLE
json2junit.py: write OE tags if provided in json

### DIFF
--- a/yocto/json2junit.py
+++ b/yocto/json2junit.py
@@ -75,6 +75,13 @@ class TestSuite:
             tc.setAttribute('timestamp', self.iso_time)
         if 'duration' in result:
             tc.setAttribute('time', str(result['duration']))
+        if 'oetags' in result:
+            properties = self.doc.createElement('properties')
+            oetags = self.doc.createElement('property')
+            oetags.setAttribute('name', 'oetags')
+            oetags.setAttribute('value', str(result['oetags']))
+            properties.appendChild(oetags)
+            tc.appendChild(properties)
         status = result['status']
         if status == 'FAILED':
             extra = self.doc.createElement('failure')


### PR DESCRIPTION
Recent Yocto versions added support for this, so if OE tags
are present it is written into the JUnit as properties

Signed-off-by: Oleksandr Pozniak <oleksandr.pozniak@daimler.com>